### PR TITLE
#26: Redo the Gemini2 exception tree entirely and move to its own file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ install:
   - pip install pylint
 script:
   - pylint point/nexstar.py
+  - pylint point/gemini_exceptions.py

--- a/point/gemini.py
+++ b/point/gemini.py
@@ -3,6 +3,7 @@ import time
 import calendar
 import point.gemini_backend
 from point.gemini_commands import *
+from point.gemini_exceptions import *
 
 
 __all__ = ['Gemini2']
@@ -376,7 +377,7 @@ class Gemini2(object):
 #    def move(self, direction):
 #        """Move in a direction: 'east', 'west', 'north', or 'south'."""
 #        if direction not in ['east', 'west', 'north', 'south']:
-#            raise ValueError('invalid direction for move command')
+#            raise ValueError('invalid direction for move command') # TODO: consider using an exception derived from Gemini2Exception!
 #        self.lx200_cmd('M' + direction[0])
 
     # TODO: reimplement this

--- a/point/gemini_exceptions.py
+++ b/point/gemini_exceptions.py
@@ -1,0 +1,111 @@
+"""Gemini2 Exception Inheritance Tree
+
+Gemini2Exception
+  G2BackendException
+     G2BackendCommandNotSupportedError
+     G2BackendFeatureNotSupportedError
+     G2BackendFeatureNotImplementedYetError
+     G2BackendCommandError
+     G2BackendResponseError
+     G2BackendReadTimeoutError
+  G2CommandException
+     G2CommandParameterError
+        G2CommandParameterTypeError
+  G2ResponseException
+     G2ResponseDecodeError
+        G2ResponseTooShortError
+        G2ResponseMissingTerminatorError
+        G2ResponseTooFewDelimitersError
+        G2ResponseChecksumMismatchError
+     G2ResponseParseError
+        G2ResponseIntegerParseError
+        G2ResponseAngleParseError
+        G2ResponseTimeParseError
+        G2ResponseRevisionsParseError
+     G2ResponseBoundsViolation
+        G2ResponseIntegerBoundsViolation
+     G2ResponseInterpretationFailure
+"""
+
+
+class Gemini2Exception(Exception): pass
+    """Base class for ALL exceptions that may be raised by ANY Gemini2 code"""
+
+
+class G2BackendException(Gemini2Exception): pass
+    """Base class for exceptions raised by the Gemini2 serial or UDP backend code"""
+
+class G2CommandException(Gemini2Exception): pass
+    """Base class for exceptions raised when processing Gemini2 commands"""
+
+class G2ResponseException(Gemini2Exception): pass
+    """Base class for exceptions raised when processing Gemini2 responses"""
+
+
+class G2BackendCommandNotSupportedError(G2BackendException): pass
+class G2BackendFeatureNotSupportedError(G2BackendException): pass
+class G2BackendFeatureNotImplementedYetError(G2BackendException): pass
+class G2BackendCommandError(G2BackendException): pass
+class G2BackendResponseError(G2BackendException): pass
+class G2BackendReadTimeoutError(G2BackendException): pass
+
+
+class G2CommandParameterError(G2CommandException): pass
+    """These are raised when a Gemini2 command is created with invalid parameters"""
+
+class G2CommandParameterTypeError(G2CommandParameterError):
+    def __init__(self, *types):
+        if len(types) == 1:
+            super().__init__('command expects 1 parameter with type {:s}'.format(types[0]))
+        else:
+            super().__init__('command expects {:d} parameters with types: {:s}'.format(len(types), ', '.join(types)))
+
+
+class G2ResponseDecodeError(G2ResponseException): pass
+    """These are raised when a Gemini2 response cannot be decoded properly"""
+
+class G2ResponseTooShortError(G2ResponseDecodeError):
+    """Raised when a fixed-length response is presented with fewer characters than it expects"""
+    def __init__(self, buf_len, expected):
+        super().__init__('response too short: length <= {:d}, expected {:d}'.format(buf_len, expected))
+class G2ResponseMissingTerminatorError(G2ResponseDecodeError):
+    """Raised when a hash-terminated response is presented with no '#' character"""
+    def __init__(self, buf_len):
+        super().__init__('response with length <= {:d} not terminated with a \'#\' character'.format(buf_len))
+class G2ResponseTooFewDelimitersError(G2ResponseDecodeError):
+    """Raised when a semicolon-delimited response is presented with fewer semicolons than it expects"""
+    def __init__(self, buf_len, actual, expected):
+        super().__init__('response contains too few delimiters: length <= {:d}; {:d} fields, expected {:d}'.format(buf_len, actual, expected))
+class G2ResponseChecksumMismatchError(G2ResponseDecodeError):
+    """Raised when a native response has a checksum mismatch"""
+    def __init__(self, actual, expected):
+        super().__init__('checksum mismatch in response to native command: {:02x}, expected {:02x}'.format(actual, expected))
+
+
+class G2ResponseParseError(G2ResponseException): pass
+    """These are raised when a Gemini2 response cannot be parsed properly"""
+
+class G2ResponseIntegerParseError(G2ResponseParseError):
+    def __init__(self, string):
+        super().__init__('failed to parse \'{:s}\' as integer'.format(string))
+class G2ResponseAngleParseError(G2ResponseParseError):
+    def __init__(self, string, precision):
+        super().__init__('failed to parse \'{:s}\' as angle ({:s} precision)'.format(string, precision))
+class G2ResponseTimeParseError(G2ResponseParseError):
+    def __init__(self, string, precision):
+        super().__init__('failed to parse \'{:s}\' as time ({:s} precision)'.format(string, precision))
+class G2ResponseRevisionsParseError(G2ResponseParseError):
+    def __init__(self, string):
+        super().__init__('failed to parse \'{:s}\' as G2 native command #97 eight-character revisions parameter'.format(string))
+
+
+class G2ResponseBoundsViolation(G2ResponseException): pass
+    """These are raised when a Gemini2 response contains a value which exceeds allowable bounds"""
+
+class G2ResponseIntegerBoundsViolation(G2ResponseBoundsViolation):
+    def __init__(self, val, bound_min, bound_max):
+        super().__init__('successfully-parsed integer {:d} violates its prescribed bounds: [{:s}, {:s}]'.format(val, bound_min, bound_max))
+
+
+class G2ResponseInterpretationFailure(G2ResponseException): pass
+    """these are raised when a Gemini2 response cannot be interpreted properly"""

--- a/point/gemini_exceptions.py
+++ b/point/gemini_exceptions.py
@@ -28,17 +28,17 @@ Gemini2Exception
 """
 
 
-class Gemini2Exception(Exception): pass
+class Gemini2Exception(Exception):
     """Base class for ALL exceptions that may be raised by ANY Gemini2 code"""
 
 
-class G2BackendException(Gemini2Exception): pass
+class G2BackendException(Gemini2Exception):
     """Base class for exceptions raised by the Gemini2 serial or UDP backend code"""
 
-class G2CommandException(Gemini2Exception): pass
+class G2CommandException(Gemini2Exception):
     """Base class for exceptions raised when processing Gemini2 commands"""
 
-class G2ResponseException(Gemini2Exception): pass
+class G2ResponseException(Gemini2Exception):
     """Base class for exceptions raised when processing Gemini2 responses"""
 
 
@@ -50,7 +50,7 @@ class G2BackendResponseError(G2BackendException): pass
 class G2BackendReadTimeoutError(G2BackendException): pass
 
 
-class G2CommandParameterError(G2CommandException): pass
+class G2CommandParameterError(G2CommandException):
     """These are raised when a Gemini2 command is created with invalid parameters"""
 
 class G2CommandParameterTypeError(G2CommandParameterError):
@@ -61,7 +61,7 @@ class G2CommandParameterTypeError(G2CommandParameterError):
             super().__init__('command expects {:d} parameters with types: {:s}'.format(len(types), ', '.join(types)))
 
 
-class G2ResponseDecodeError(G2ResponseException): pass
+class G2ResponseDecodeError(G2ResponseException):
     """These are raised when a Gemini2 response cannot be decoded properly"""
 
 class G2ResponseTooShortError(G2ResponseDecodeError):
@@ -82,7 +82,7 @@ class G2ResponseChecksumMismatchError(G2ResponseDecodeError):
         super().__init__('checksum mismatch in response to native command: {:02x}, expected {:02x}'.format(actual, expected))
 
 
-class G2ResponseParseError(G2ResponseException): pass
+class G2ResponseParseError(G2ResponseException):
     """These are raised when a Gemini2 response cannot be parsed properly"""
 
 class G2ResponseIntegerParseError(G2ResponseParseError):
@@ -99,7 +99,7 @@ class G2ResponseRevisionsParseError(G2ResponseParseError):
         super().__init__('failed to parse \'{:s}\' as G2 native command #97 eight-character revisions parameter'.format(string))
 
 
-class G2ResponseBoundsViolation(G2ResponseException): pass
+class G2ResponseBoundsViolation(G2ResponseException):
     """These are raised when a Gemini2 response contains a value which exceeds allowable bounds"""
 
 class G2ResponseIntegerBoundsViolation(G2ResponseBoundsViolation):
@@ -107,5 +107,5 @@ class G2ResponseIntegerBoundsViolation(G2ResponseBoundsViolation):
         super().__init__('successfully-parsed integer {:d} violates its prescribed bounds: [{:s}, {:s}]'.format(val, bound_min, bound_max))
 
 
-class G2ResponseInterpretationFailure(G2ResponseException): pass
+class G2ResponseInterpretationFailure(G2ResponseException):
     """these are raised when a Gemini2 response cannot be interpreted properly"""

--- a/point/gemini_exceptions.py
+++ b/point/gemini_exceptions.py
@@ -42,23 +42,36 @@ class G2ResponseException(Gemini2Exception):
     """Base class for exceptions raised when processing Gemini2 responses"""
 
 
-class G2BackendCommandNotSupportedError(G2BackendException): pass
-class G2BackendFeatureNotSupportedError(G2BackendException): pass
-class G2BackendFeatureNotImplementedYetError(G2BackendException): pass
-class G2BackendCommandError(G2BackendException): pass
-class G2BackendResponseError(G2BackendException): pass
-class G2BackendReadTimeoutError(G2BackendException): pass
+class G2BackendCommandNotSupportedError(G2BackendException):
+    """Raised when a command is not supported"""
+
+class G2BackendFeatureNotSupportedError(G2BackendException):
+    """Raised when a feature is not supported"""
+
+class G2BackendFeatureNotImplementedYetError(G2BackendException):
+    """Raised when a feature is not implemented yet, but might be in the future"""
+
+class G2BackendCommandError(G2BackendException):
+    """Raised when a command error is encountered in the backend"""
+
+class G2BackendResponseError(G2BackendException):
+    """Raised when a response error is encountered in the backend"""
+
+class G2BackendReadTimeoutError(G2BackendException):
+    """Raised when a read operation times out"""
 
 
 class G2CommandParameterError(G2CommandException):
     """These are raised when a Gemini2 command is created with invalid parameters"""
 
 class G2CommandParameterTypeError(G2CommandParameterError):
+    """Raised when parameters passed to the command do not match expectations"""
     def __init__(self, *types):
         if len(types) == 1:
             super().__init__('command expects 1 parameter with type {:s}'.format(types[0]))
         else:
-            super().__init__('command expects {:d} parameters with types: {:s}'.format(len(types), ', '.join(types)))
+            super().__init__('command expects {:d} parameters with types: {:s}'.format(
+                len(types), ', '.join(types)))
 
 
 class G2ResponseDecodeError(G2ResponseException):
@@ -67,44 +80,62 @@ class G2ResponseDecodeError(G2ResponseException):
 class G2ResponseTooShortError(G2ResponseDecodeError):
     """Raised when a fixed-length response is presented with fewer characters than it expects"""
     def __init__(self, buf_len, expected):
-        super().__init__('response too short: length <= {:d}, expected {:d}'.format(buf_len, expected))
+        super().__init__('response too short: length <= {:d}, expected {:d}'.format(
+            buf_len, expected))
 class G2ResponseMissingTerminatorError(G2ResponseDecodeError):
     """Raised when a hash-terminated response is presented with no '#' character"""
     def __init__(self, buf_len):
-        super().__init__('response with length <= {:d} not terminated with a \'#\' character'.format(buf_len))
+        super().__init__(
+            'response with length <= {:d} not terminated with a \'#\' character'.format(buf_len))
 class G2ResponseTooFewDelimitersError(G2ResponseDecodeError):
-    """Raised when a semicolon-delimited response is presented with fewer semicolons than it expects"""
+    """Raised when a semicolon-delimited response is presented with fewer semicolons than it
+    expects
+    """
     def __init__(self, buf_len, actual, expected):
-        super().__init__('response contains too few delimiters: length <= {:d}; {:d} fields, expected {:d}'.format(buf_len, actual, expected))
+        super().__init__('response contains too few delimiters: length <= {:d}; {:d} fields, '
+                         'expected {:d}'.format(buf_len, actual, expected))
 class G2ResponseChecksumMismatchError(G2ResponseDecodeError):
     """Raised when a native response has a checksum mismatch"""
     def __init__(self, actual, expected):
-        super().__init__('checksum mismatch in response to native command: {:02x}, expected {:02x}'.format(actual, expected))
+        super().__init__('checksum mismatch in response to native command: {:02x}, '
+                         'expected {:02x}'.format(actual, expected))
 
 
 class G2ResponseParseError(G2ResponseException):
     """These are raised when a Gemini2 response cannot be parsed properly"""
 
 class G2ResponseIntegerParseError(G2ResponseParseError):
+    """Raised when a response cannot be parsed as an integer"""
     def __init__(self, string):
         super().__init__('failed to parse \'{:s}\' as integer'.format(string))
+
 class G2ResponseAngleParseError(G2ResponseParseError):
+    """Raised when a response cannot be parsed as an angle"""
     def __init__(self, string, precision):
-        super().__init__('failed to parse \'{:s}\' as angle ({:s} precision)'.format(string, precision))
+        super().__init__('failed to parse \'{:s}\' as angle ({:s} precision)'.format(
+            string, precision))
+
 class G2ResponseTimeParseError(G2ResponseParseError):
+    """Raised when a response cannot be parsed as a time value"""
     def __init__(self, string, precision):
-        super().__init__('failed to parse \'{:s}\' as time ({:s} precision)'.format(string, precision))
+        super().__init__('failed to parse \'{:s}\' as time ({:s} precision)'.format(
+            string, precision))
+
 class G2ResponseRevisionsParseError(G2ResponseParseError):
+    """Raised when a response cannot be parsed as an 8-character revision"""
     def __init__(self, string):
-        super().__init__('failed to parse \'{:s}\' as G2 native command #97 eight-character revisions parameter'.format(string))
+        super().__init__('failed to parse \'{:s}\' as G2 native command #97 eight-character '
+                         'revisions parameter'.format(string))
 
 
 class G2ResponseBoundsViolation(G2ResponseException):
     """These are raised when a Gemini2 response contains a value which exceeds allowable bounds"""
 
 class G2ResponseIntegerBoundsViolation(G2ResponseBoundsViolation):
+    """Raised when an integer response value is out of bounds"""
     def __init__(self, val, bound_min, bound_max):
-        super().__init__('successfully-parsed integer {:d} violates its prescribed bounds: [{:s}, {:s}]'.format(val, bound_min, bound_max))
+        super().__init__('successfully-parsed integer {:d} violates its prescribed bounds: '
+                         '[{:s}, {:s}]'.format(val, bound_min, bound_max))
 
 
 class G2ResponseInterpretationFailure(G2ResponseException):


### PR DESCRIPTION
This should squash any problems mentioned in #26 related to trying to raise exceptions improperly.

The main notable thing done here is to get rid of the various Gemini2-related exceptions scattered about in multiple modules and multiple classes, and instead introduce a **single, unified** class hierarchy for **all** Gemini2-related exceptions, located in its own module.

This rework should, among other things, make it infinitely easier to create `try/except` statements that will catch whatever sub-group of Gemini2-related exceptions are wanted.

Yes, technically it's "better" to have the exceptions be located in the various classes themselves, and then have to do long, potentially-error prone things like `except point.gemini_commands.Gemini2Response.MissingTerminatorError as e:`; but I think doing `from point.gemini_exceptions import *` and then `except G2ResponseMissingTerminatorError as e:` instead, and having one centralized, easy-to-understand class hierarchy in one place, is ultimately better from a pragmatic point of view.