### PR TITLE
Fix a Python <3.6 compat issue related to re.Match.__getitem__

### DIFF
--- a/point/gemini_commands.py
+++ b/point/gemini_commands.py
@@ -78,9 +78,9 @@ def parse_time_dbl(string):
 def parse_time_hilo(string):
     match = _re_time_hilo.fullmatch(string)
     if match is None: raise G2ResponseTimeParseError(string, 'high/low')
-    i_hour = int(match[1])
-    i_min  = int(match[2])
-    i_sec  = int(match[3])
+    i_hour = int(match.group(1))
+    i_min  = int(match.group(2))
+    i_sec  = int(match.group(3))
     # TODO: bounds check on hour field...? and should we even be limiting the hour field to 2 digits in the RE?
     if i_min >= 60 or i_sec >= 60: raise G2ResponseTimeParseError(string, 'high/low')
     return float((i_hour * 3600) + (i_min * 60) + i_sec)


### PR DESCRIPTION
The code now uses `re.Match.group` instead of subscripting `re.Match`, making it compatible with versions older than Python 3.6.