### PR TITLE
Async slew commanding with multiprocessing

### DIFF
--- a/point/gemini.py
+++ b/point/gemini.py
@@ -104,7 +104,7 @@ class Gemini2(object):
                 )
                 self._slew_rate_processes[axis].start()
         else:
-            now = time.time()
+            now = time.perf_counter()
             self._div_last_commanded = {'ra': 0, 'dec': 0}
             self._time_last_commanded = {'ra': now, 'dec': now}
 
@@ -627,7 +627,7 @@ class Gemini2(object):
         Returns:
             The actual rate commanded.
         """
-        time_current = time.time()
+        time_current = time.perf_counter()
         rate_last_commanded = self.div_to_slew_rate(self._div_last_commanded[axis])
         rate_to_command = self._apply_rate_accel_limit(
             rate_desired,
@@ -668,7 +668,7 @@ class Gemini2(object):
         axis_safe_event.set()
         div_last_commanded = 0
         div_target = 0
-        time_last_commanded = time.time() - 1e-3
+        time_last_commanded = time.perf_counter() - 1e-3
         shutdown = False
 
         while True:
@@ -688,7 +688,7 @@ class Gemini2(object):
                     if div_target == div_last_commanded:
                         continue
 
-            time_current = time.time()
+            time_current = time.perf_counter()
 
             # may not be able to achieve div_target if it exceeds rate accel or step limits
             rate_target = self.div_to_slew_rate(div_target)

--- a/point/gemini_backend.py
+++ b/point/gemini_backend.py
@@ -3,6 +3,8 @@ import serial
 import socket
 import struct
 import string
+import signal
+import multiprocessing
 import threading
 import point.gemini_commands
 from point.gemini_exceptions import *
@@ -155,9 +157,17 @@ class Gemini2BackendUDP(Gemini2Backend):
         self._stats['dgram_nack_tx'] = 0
         self._stats['dgram_nack_rx'] = 0
 
-        self._command_lock = threading.Lock()
+        self._command_lock = multiprocessing.Lock()
 
     def execute_one_command(self, cmd):
+        self._command_lock.acquire()
+        try:
+            resp = self._execute_one_command(cmd)
+        finally:
+            self._command_lock.release()
+        return resp
+
+    def _execute_one_command(self, cmd):
         if not cmd.valid_for_udp():
             raise G2BackendCommandNotSupportedError('command {:s} is not supported on the UDP backend'.format(cmd.__class__.__name__))
 
@@ -173,12 +183,6 @@ class Gemini2BackendUDP(Gemini2Backend):
         # over here we can specifically wait on receiving a datagram with the actual seqnum we want?
         # OR: integrate the seqnum/last_seqnum processing into a separate function, so that we can
         # rapidly identify it and just immediately loop back to recv again if it's wrong
-
-        # TODO: We have a problem if CTRL-C occurs while this lock is acquired, since then when
-        # stop_motion() is called on the Gemini class it will block forever waiting for this lock.
-        # We really need a way to defer SIGINT. This looks promising:
-        # https://stackoverflow.com/a/21919644/2475856
-        self._command_lock.acquire()
 
         # upon a successful NACK that indicates the command was not received, we'll end up back here
         while True:
@@ -204,7 +208,6 @@ class Gemini2BackendUDP(Gemini2Backend):
                 retry_num = 0
                 while True:
                     if retry_num >= self._retry_limit:
-                        self._command_lock.release()
                         raise G2BackendReadTimeoutError('gave up after {:d} NACK retry attempts'.format(retry_num))
                     retry_num += 1
                     self._seqnum += 1
@@ -223,10 +226,8 @@ class Gemini2BackendUDP(Gemini2Backend):
                 self._stats['dgram_cmd_rx'] += 1
 
             if len(buf_resp) > self.UDP_RESP_DGRAM_LEN_MAX:
-                self._command_lock.release()
                 raise G2BackendResponseError('received UDP response datagram larger than max length: {:d} > {:d}'.format(len(buf_resp), self.UDP_RESP_DGRAM_LEN_MAX))
             elif len(buf_resp) < self.UDP_RESP_DGRAM_LEN_MIN:
-                self._command_lock.release()
                 raise G2BackendResponseError('received UDP response datagram smaller than min length: {:d} < {:d}'.format(len(buf_resp), self.UDP_RESP_DGRAM_LEN_MIN))
 
             (seqnum, last_seqnum) = struct.unpack('!II', buf_resp[0:8])
@@ -237,7 +238,6 @@ class Gemini2BackendUDP(Gemini2Backend):
                     skip_send = True
                     continue
                 elif seqnum < cmd_seqnum or seqnum > self._seqnum:
-                    self._command_lock.release()
                     raise G2BackendResponseError('mismatched sequence number in UDP response datagram: {:d} != {:d}'.format(seqnum, self._seqnum))
 
             if did_retry:
@@ -258,32 +258,25 @@ class Gemini2BackendUDP(Gemini2Backend):
 
             num_nulls = buf_resp.count('\x00')
             if num_nulls == 0:
-                self._command_lock.release()
                 raise G2BackendResponseError('received UDP response buffer of length {:d} containing no NULL terminator'.format(len(buf_resp)))
             elif num_nulls > 1:
-                self._command_lock.release()
                 raise G2BackendResponseError('received UDP response buffer of length {:d} containing {:d} NULL characters'.format(len(buf_resp), num_nulls))
             elif buf_resp[-1] != '\x00':
-                self._command_lock.release()
                 raise G2BackendResponseError('received UDP response buffer of length {:d} with single NULL terminator at non-end index {:d}'.format(len(buf_resp), string.rfind(buf_resp, '\x00')))
             buf_resp = buf_resp[:-1]
 
             resp = cmd.response()
             if len(buf_resp) == 1 and buf_resp[0] == '\x06':
                 if not resp is None:
-                    self._command_lock.release()
                     raise G2BackendResponseError('received ACK (no response), but command {:s} expected to receive response {:s}'.format(cmd.__class__.__name__, resp.__class__.__name__))
             else:
                 if resp is None:
-                    self._command_lock.release()
                     raise G2BackendResponseError('received a response of some kind, but command {:s} was expecting no response'.format(cmd.__class__.__name__))
                 len_consumed = resp.decode(buf_resp)
                 if len_consumed != len(buf_resp):
-                    self._command_lock.release()
                     raise G2BackendResponseError('response was decoded, but only {:d} of the {:d} available characters were consumed'.format(len_consumed, len(buf_resp)))
 
             self._stats['cmd_exec'] += 1
-            self._command_lock.release()
             return resp
 
     def execute_multiple_commands(self, *cmds):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.4',
+    version='0.4.0',
 
     description='Serial command interfaces for telescopes',
     long_description=long_description,
@@ -29,7 +29,7 @@ setup(
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Topic :: Scientific/Engineering :: Astronomy',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This resolves a long-standing issue with the Gemini mount where the smoothness of acceleration was dependent on how quickly calls to `slew()` could be made by the user code. This is because the low-level commands sent to Gemini set the slew rate divisors directly, and thus any acceleration limiting (which is essential to avoid motor stalls) must be handled by this software. This PR adds multiprocessing support such that divisor commands can be sent rapidly to Gemini asynchronously until the target slew rate has been achieved or a new target is set. Tests performed thus far show that this makes a huge difference:

- Allows far less conservative acceleration limits (40 deg/s/s rather than 10 deg/s/s) without risking motor stalls. Less conservative acceleration limits make higher-level control software more stable.
- Acceleration and deceleration is significantly smoother when used with applications in the `track` package that have a control cycle of ~15 Hz. The asynchronous commanding enabled by this PR can run as fast as 500 Hz.

Multiprocessing was chosen because no other option seemed viable. Threading was attempted but it was quickly realized that the CPython GIL prevents this approach from working. Since this feature may be unnecessary or cause issues for some applications the feature was made an optional extra that is disabled by default.